### PR TITLE
tgenv-list: Handle missing default version gracefully

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -77,7 +77,7 @@ version="$(tgenv-list-remote | grep -e "${regex}" | head -n 1)";
 
 dst_path="${TGENV_ROOT}/versions/${version}";
 if [ -f "${dst_path}/terragrunt" ]; then
-  echo "Terraform v${version} is already installed";
+  echo "Terragrunt v${version} is already installed";
   exit 0;
 fi;
 
@@ -114,7 +114,7 @@ tarball_name="terragrunt_${os}";
 
 # shasums_name="terragrunt_${version}_SHA256SUMS";
 
-log 'info' "Installing Terraform v${version}";
+log 'info' "Installing Terragrunt v${version}";
 
 # # Create a local temporary directory for downloads
 # download_tmp="$(mktemp -d tgenv_download.XXXXXX)" || log 'error' "Unable to create temporary download directory in $(pwd)";

--- a/libexec/tgenv-list
+++ b/libexec/tgenv-list
@@ -68,9 +68,8 @@ done;
 [[ -x "${TGENV_ROOT}/versions" && -r "${TGENV_ROOT}/versions" ]] \
   || log 'error' "tgenv versions directory is inaccessible: ${TGENV_ROOT}/versions";
 
-version_name="$(tgenv-version-name)" \
-  && log 'debug' "tgenv-version-name reported: ${version_name}" \
-  || log 'error' "tgenv-version-name failed";
+version_name="$(tgenv-version-name 2>/dev/null || true)" \
+  && log 'debug' "tgenv-version-name reported: ${version_name}";
 export version_name;
 
 version_file="$(tgenv-version-file)" \
@@ -78,9 +77,13 @@ version_file="$(tgenv-version-file)" \
   || log 'error' "tgenv-version-file failed";
 export version_file;
 
+# Register for whether a default terraform version has yet been set
+declare -i default_set=0;
+
 print_version () {
   if [ "${1}" == "${version_name}" ]; then
     echo "* ${1} (set by ${version_file})";
+    default_set=1
   else
     echo "  ${1}";
   fi;
@@ -97,3 +100,9 @@ log 'debug' 'Printing versions...';
 for local_version in ${local_versions[@]}; do
   print_version "${local_version}";
 done;
+
+log 'debug' "default_set == ${default_set}"
+
+[ "${default_set}" -eq 0 ] && log 'info' "No default set. Set with 'tgenv use <version>'";
+
+exit 0;


### PR DESCRIPTION
This PR contains a fix for `tgenv-list` in order that a missing default version (no file `version` in `TGENV_ROOT) does not end the command with an error but prints a corresponding message.

In addition the string `Terraform` has been replaced with `Terragrunt` in `tgenv-install`
