### PR TITLE
Fix tg/tf references

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ $ rm -rf /some/path/to/tgenv
 ## LICENSES
 
 - [tfenv]
-  - tgenv uses a majority of tgenv's source code.
+  - tgenv uses a majority of tfenv's source code.
 - [rbenv]
   - tgenv partially uses rbenv's source code
 

--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -77,7 +77,7 @@ version="$(tgenv-list-remote | grep -e "${regex}" | head -n 1)";
 
 dst_path="${TGENV_ROOT}/versions/${version}";
 if [ -f "${dst_path}/terragrunt" ]; then
-  echo "Terraform v${version} is already installed";
+  echo "Terragrunt v${version} is already installed";
   exit 0;
 fi;
 
@@ -114,7 +114,7 @@ tarball_name="terragrunt_${os}";
 
 # shasums_name="terragrunt_${version}_SHA256SUMS";
 
-log 'info' "Installing Terraform v${version}";
+log 'info' "Installing Terragrunt v${version}";
 
 # # Create a local temporary directory for downloads
 # download_tmp="$(mktemp -d tgenv_download.XXXXXX)" || log 'error' "Unable to create temporary download directory in $(pwd)";


### PR DESCRIPTION
In some places Terraform was named instead of Terragrunt and vice versa.

Resolves https://github.com/taosmountain/tgenv/issues/3