### PR TITLE
Fix arm64 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ String (Default: amd64)
 Specify architecture. Architecture other than the default amd64 can be specified with the `TGENV_ARCH` environment variable
 
 ```console
-TGENV_ARCH=arm tgenv install 0.25.5
+TGENV_ARCH=arm64 tgenv install 0.25.5
 ```
 
 ##### `TGENV_AUTO_INSTALL`


### PR DESCRIPTION
I believe `TGENV_ARCH=arm64` is a correct value. Otherwise it tries to download `terragrunt` from https://github.com/gruntwork-io/terragrunt/releases/download/v0.38.6/terragrunt_linux_arm (404) instead of https://github.com/gruntwork-io/terragrunt/releases/download/v0.38.6/terragrunt_linux_arm64
```
> [linux/arm64 3/4] RUN bash -xe /add_deps.sh:
#11 8.009 ++ PATH=/home/runner/.local/bin:/home/runner/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/runner/.local/bin/
#11 8.009 + ln -s /home/runner/.tgenv/bin/terragrunt /home/runner/.tgenv/bin/tgenv /home/runner/.local/bin
#11 8.011 + which tgenv
#11 8.012 /home/runner/.local/bin/tgenv
#11 8.013 + tgenv install 0.38.6
#11 8.460 Installing Terraform v0.38.6
#11 8.476 Downloading release tarball from https://github.com/gruntwork-io/terragrunt/releases/download/v0.38.6/terragrunt_linux_arm
#11 8.668 #=#=#                                                                         
curl: (22) The requested URL returned error: 404 
#11 8.669 
#11 8.679 Tarball download failed
------
Dockerfile:9
--------------------
   7 |     
   8 |     COPY ["_rootfs", "/"]
   9 | >>> RUN bash -xe /add_deps.sh
  10 |     USER root
  11 |     RUN rm /add_deps.sh
--------------------
ERROR: failed to solve: process "/bin/bash -o pipefail -c bash -xe /add_deps.sh" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/bash -o pipefail -c bash -xe /add_deps.sh" did not complete successfully: exit code: 1
```